### PR TITLE
Prevent typedoc from detecting every index file as a module

### DIFF
--- a/typedoc.json
+++ b/typedoc.json
@@ -2,6 +2,6 @@
   "$schema": "https://typedoc.org/schema.json",
   "out": "doc",
   "entryPointStrategy": "packages",
-  "entryPoints": ["./packages/**"],
+  "entryPoints": ["./packages/*"],
   "name": "Rarimo JavaScript/Typescript SDK",
 }


### PR DESCRIPTION
The typedoc.json file has this line:
```
  "entryPoints": ["./packages/**"],
```
This make typedoc see every `index` file in `packages/` as a package, at every level.

As a result, the output shows several incorrect packages:
![image](https://user-images.githubusercontent.com/6494785/223468410-346d0539-8e60-44aa-8baf-0432cc6ca0da.png)

This PR changes it so only folders at the base level of `packages/` become packages in the output:
![image](https://user-images.githubusercontent.com/6494785/223468617-069405bb-7013-4b21-921c-7cf388bf4f66.png)

To test:
1. Load this PR
2. Run `yarn install && yarn build && yarn doc`
3. Look at the file doc/index.html and verify that it shows only the provider and NFT checkout packages.