### PR TITLE
React typedoc

### DIFF
--- a/packages/react-nft-checkout/README.md
+++ b/packages/react-nft-checkout/README.md
@@ -1,4 +1,5 @@
 # @rarimo/react-nft-checkout
+Features of the Rarimo SDK that provide React components to manage cross-train transactions with the Rarimo protocol.
 
 # Installation
 
@@ -26,3 +27,7 @@ or
 ```bash
 yarn add @rarimo/react-nft-checkout --no-optional
 ```
+
+## Changelog
+
+For the change log, see [CHANGELOG.md](https://github.com/rarimo/js-sdk/blob/main/CHANGELOG.md).

--- a/packages/react-nft-checkout/package.json
+++ b/packages/react-nft-checkout/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@rarimo/react-nft-checkout",
   "version": "1.4.0",
+  "description": "React components that you can use in your UI to create cross-chain transactions with the Rarimo Protocol",
   "license": "MIT",
   "sideEffects": false,
   "types": "index.d.ts",

--- a/packages/react-nft-checkout/src/components/AppButton/AppButton.tsx
+++ b/packages/react-nft-checkout/src/components/AppButton/AppButton.tsx
@@ -3,7 +3,9 @@ import { Button, ButtonProps } from '@mui/material'
 export type AppButtonProps = ButtonProps
 
 /**
- * @description A generic UI button
+ * @description A generic UI button that extends the Material UI Button component
+ * @group Components
+ * @see https://mui.com/material-ui/react-button/
  */
 const AppButton = ({ children, ...props }: AppButtonProps) => {
   return (

--- a/packages/react-nft-checkout/src/components/AppButton/AppButton.tsx
+++ b/packages/react-nft-checkout/src/components/AppButton/AppButton.tsx
@@ -2,6 +2,9 @@ import { Button, ButtonProps } from '@mui/material'
 
 export type AppButtonProps = ButtonProps
 
+/**
+ * @description A generic UI button
+ */
 const AppButton = ({ children, ...props }: AppButtonProps) => {
   return (
     <Button variant="contained" {...props}>

--- a/packages/react-nft-checkout/src/components/BridgeChainSelect/BridgeChainSelect.tsx
+++ b/packages/react-nft-checkout/src/components/BridgeChainSelect/BridgeChainSelect.tsx
@@ -14,6 +14,9 @@ import { useDappContext } from '@/hooks'
 
 import styles from './BridgeChainSelect.module.css'
 
+/**
+ * @description A drop-down list for selecting the chain to use
+ */
 const BridgeChainSelect = () => {
   const { supportedChains, selectedChain, setSelectedChain } = useDappContext()
 

--- a/packages/react-nft-checkout/src/components/BridgeChainSelect/BridgeChainSelect.tsx
+++ b/packages/react-nft-checkout/src/components/BridgeChainSelect/BridgeChainSelect.tsx
@@ -16,6 +16,7 @@ import styles from './BridgeChainSelect.module.css'
 
 /**
  * @description A drop-down list for selecting the chain to use
+ * @group Components
  */
 const BridgeChainSelect = () => {
   const { supportedChains, selectedChain, setSelectedChain } = useDappContext()

--- a/packages/react-nft-checkout/src/components/CheckoutModal/CheckoutModal.tsx
+++ b/packages/react-nft-checkout/src/components/CheckoutModal/CheckoutModal.tsx
@@ -13,6 +13,9 @@ import {
 } from '@/components'
 import { useDappContext } from '@/hooks'
 
+/**
+ * @description A window that shows the transaction details and allows the user to confirm the transaction
+ */
 const CheckoutModal = () => {
   const {
     isInitialized,

--- a/packages/react-nft-checkout/src/components/CheckoutModal/CheckoutModal.tsx
+++ b/packages/react-nft-checkout/src/components/CheckoutModal/CheckoutModal.tsx
@@ -15,6 +15,7 @@ import { useDappContext } from '@/hooks'
 
 /**
  * @description A window that shows the transaction details and allows the user to confirm the transaction
+ * @group Components
  */
 const CheckoutModal = () => {
   const {

--- a/packages/react-nft-checkout/src/components/ErrorText/ErrorText.tsx
+++ b/packages/react-nft-checkout/src/components/ErrorText/ErrorText.tsx
@@ -6,6 +6,12 @@ interface Props {
   variant?: Variant | 'inherit'
 }
 
+/**
+ * @description An error message
+ *
+ * @param props.text The error message
+ * @param props.variant The text variant for the Material UI Typography component
+ */
 const ErrorText = ({ text, variant = 'subtitle2' }: Props) => {
   return (
     <Typography

--- a/packages/react-nft-checkout/src/components/ErrorText/ErrorText.tsx
+++ b/packages/react-nft-checkout/src/components/ErrorText/ErrorText.tsx
@@ -8,9 +8,11 @@ interface Props {
 
 /**
  * @description An error message
+ * @group Components
  *
- * @param props.text The error message
- * @param props.variant The text variant for the Material UI Typography component
+ * @param props The properties for the component, including:
+ * - `text`: The text of the error message
+ * - `variant`: The Material UI Typography component
  */
 const ErrorText = ({ text, variant = 'subtitle2' }: Props) => {
   return (

--- a/packages/react-nft-checkout/src/components/LoadingIndicator/LoadingIndicator.tsx
+++ b/packages/react-nft-checkout/src/components/LoadingIndicator/LoadingIndicator.tsx
@@ -2,8 +2,10 @@ import { Box, CircularProgress, Typography } from '@mui/material'
 
 /**
  * @description A loading indicator with a message
+ * @group Components
  *
- * @param props.text The message to show during loading
+ * @param props The properties for the component, including:
+ * - `text`: The message to show during loading
  */
 const LoadingIndicator = ({ text }: { text: string }) => {
   return (

--- a/packages/react-nft-checkout/src/components/LoadingIndicator/LoadingIndicator.tsx
+++ b/packages/react-nft-checkout/src/components/LoadingIndicator/LoadingIndicator.tsx
@@ -1,5 +1,10 @@
 import { Box, CircularProgress, Typography } from '@mui/material'
 
+/**
+ * @description A loading indicator with a message
+ *
+ * @param props.text The message to show during loading
+ */
 const LoadingIndicator = ({ text }: { text: string }) => {
   return (
     <Box

--- a/packages/react-nft-checkout/src/components/PaymentTokensList/PaymentTokensList.tsx
+++ b/packages/react-nft-checkout/src/components/PaymentTokensList/PaymentTokensList.tsx
@@ -12,6 +12,9 @@ import { useEffect, useState } from 'react'
 import { ErrorText, LoadingIndicator } from '@/components'
 import { useDappContext } from '@/hooks'
 
+/**
+ * @description A list of the tokens in the user's selected wallet
+ */
 const PaymentTokensList = () => {
   const {
     selectedChain,

--- a/packages/react-nft-checkout/src/components/PaymentTokensList/PaymentTokensList.tsx
+++ b/packages/react-nft-checkout/src/components/PaymentTokensList/PaymentTokensList.tsx
@@ -14,6 +14,7 @@ import { useDappContext } from '@/hooks'
 
 /**
  * @description A list of the tokens in the user's selected wallet
+ * @group Components
  */
 const PaymentTokensList = () => {
   const {

--- a/packages/react-nft-checkout/src/components/PaymentWallets/PaymentWallets.tsx
+++ b/packages/react-nft-checkout/src/components/PaymentWallets/PaymentWallets.tsx
@@ -31,6 +31,9 @@ const PROVIDERS_DATA = [
   },
 ]
 
+/**
+ * @description A list of the wallets detected in the user's browser
+ */
 const PaymentWallets = () => {
   const { provider, setSelectedProviderProxy, createProviderError } =
     useDappContext()

--- a/packages/react-nft-checkout/src/components/PaymentWallets/PaymentWallets.tsx
+++ b/packages/react-nft-checkout/src/components/PaymentWallets/PaymentWallets.tsx
@@ -33,6 +33,7 @@ const PROVIDERS_DATA = [
 
 /**
  * @description A list of the wallets detected in the user's browser
+ * @group Components
  */
 const PaymentWallets = () => {
   const { provider, setSelectedProviderProxy, createProviderError } =

--- a/packages/react-nft-checkout/src/components/PriceConversion/PriceConversion.tsx
+++ b/packages/react-nft-checkout/src/components/PriceConversion/PriceConversion.tsx
@@ -9,6 +9,14 @@ type Props = {
   estimatedPrice?: EstimatedPrice
 }
 
+/**
+ * @description Information about the fees for converting tokens
+ * @group Components
+ *
+ * @param props The properties for the component, including:
+ * - `isLoading`: True if the component is loading and false if it is ready
+ * - `estimatedPrice`: An {@link @rarimo/nft-checkout!EstimatedPrice} object with information about the transaction price
+ */
 const PriceConversion = ({ isLoading, estimatedPrice }: Props) => {
   const { targetNft, checkoutOperation } = useDappContext()
 

--- a/packages/react-nft-checkout/src/components/RarimoPayButton/RarimoPayButton.tsx
+++ b/packages/react-nft-checkout/src/components/RarimoPayButton/RarimoPayButton.tsx
@@ -8,11 +8,17 @@ interface Props extends AppButtonProps {
   muiTheme?: Theme
 }
 
+// Typedoc does not appear to render these props correctly because of the destructured parameter, so I made them a bulleted list.
+// See https://typedoc.org/tags/param/#destructured-parameters
+
 /**
  * @description A Buy button that starts a Rarimo transaction
+ * @group Components
  *
- * @param props.text The text for the button; the default is "Buy with Rarimo"
- * @param props.onClick The function to run when the user clicks; by default, the button opens the {@link RarimoPayDialog} component
+ * @param props The properties for the component, including:
+ * - `text`: The text for the button
+ * - `onClick`: The function to run when the user clicks; by default, the button opens the {@link RarimoPayDialog} component
+ * - `muiTheme`: The Material UI theme to apply
  */
 const RarimoPayButton = ({ muiTheme, ...props }: Props) => {
   const [isVisibleSupportedChains, setIsVisibleSupportedChains] =

--- a/packages/react-nft-checkout/src/components/RarimoPayButton/RarimoPayButton.tsx
+++ b/packages/react-nft-checkout/src/components/RarimoPayButton/RarimoPayButton.tsx
@@ -8,6 +8,12 @@ interface Props extends AppButtonProps {
   muiTheme?: Theme
 }
 
+/**
+ * @description A Buy button that starts a Rarimo transaction
+ *
+ * @param props.text The text for the button; the default is "Buy with Rarimo"
+ * @param props.onClick The function to run when the user clicks; by default, the button opens the {@link RarimoPayDialog} component
+ */
 const RarimoPayButton = ({ muiTheme, ...props }: Props) => {
   const [isVisibleSupportedChains, setIsVisibleSupportedChains] =
     useState(false)

--- a/packages/react-nft-checkout/src/components/RarimoPayDialog/RarimoPayDialog.tsx
+++ b/packages/react-nft-checkout/src/components/RarimoPayDialog/RarimoPayDialog.tsx
@@ -7,9 +7,11 @@ import styles from './RarimoPayDialog.module.css'
 
 /**
  * @description A dialog box that prompts the user to select a wallet and token to pay with via the {@link PaymentWallets} component and then the {@link PaymentTokensList} component
+ * @group Components
  *
- * @param props.open Whether to show the dialog or not
- * @param props.handleCloseDialog A function that runs when the user clicks the cancel button
+ * @param props The properties for the component, including:
+ * - `open`: Whether to show the dialog or not
+ * - `handleCloseDialog`: A function that runs when the user clicks the cancel button
  */
 const RarimoPayDialog = ({
   open,

--- a/packages/react-nft-checkout/src/components/RarimoPayDialog/RarimoPayDialog.tsx
+++ b/packages/react-nft-checkout/src/components/RarimoPayDialog/RarimoPayDialog.tsx
@@ -5,6 +5,12 @@ import { PaymentWallets } from '@/components'
 
 import styles from './RarimoPayDialog.module.css'
 
+/**
+ * @description A dialog box that prompts the user to select a wallet and token to pay with via the {@link PaymentWallets} component and then the {@link PaymentTokensList} component
+ *
+ * @param props.open Whether to show the dialog or not
+ * @param props.handleCloseDialog A function that runs when the user clicks the cancel button
+ */
 const RarimoPayDialog = ({
   open,
   handleCloseDialog,

--- a/packages/react-nft-checkout/src/components/TransactionSummary/TransactionSummary.tsx
+++ b/packages/react-nft-checkout/src/components/TransactionSummary/TransactionSummary.tsx
@@ -9,6 +9,15 @@ type Props = {
   estimatedPrice?: EstimatedPrice
 }
 
+/**
+ * @description Information about the completed transaction
+ * @group Components
+ *
+ * @param props The properties for the component, including:
+ * - `isTransactionProcessing`: True if the transaction is not yet complete
+ * - `txHash`: The transaction hash
+ * - `estimatedPrice`: An {@link @rarimo/nft-checkout!EstimatedPrice} object with information about the transaction price
+ */
 const TransactionSummary = ({
   isTransactionProcessing,
   txHash,

--- a/packages/react-nft-checkout/src/context/DappContextProvider.tsx
+++ b/packages/react-nft-checkout/src/context/DappContextProvider.tsx
@@ -50,6 +50,13 @@ export type DappContextProviderPropsType = {
 
 export const DappContext = createContext({} as DappContextType)
 
+/**
+ * @description A container for other components such as RarimoPayButton
+ * @param {Target} props.targetNft An object that represents the final NFT transaction
+ * @param props.checkoutTxBundle An encoded bundle of all of the transactions to run; see https://rarimo.gitlab.io/docs/docs/overview/bundling
+ * @param props.createProviderOpts Parameters to pass to the provider; see {@link createProviderOpts}
+ * @param props.createCheckoutOperationParams Parameters to pass to the checkout operation; see {@link createCheckoutOperation}
+ */
 export const DappContextProvider = ({
   children,
   targetNft,

--- a/packages/react-provider/src/hooks/useProvider.ts
+++ b/packages/react-provider/src/hooks/useProvider.ts
@@ -40,6 +40,19 @@ type ProviderEventPayload =
   | ProviderChainChangedEventPayload
   | ProviderInitiatedEventPayload
 
+/**
+ * @description A React hook that creates a provider object with access to the user's wallet
+ *
+ * @example
+ * ```ts
+ * const { provider, ...rest } = useProvider(MetamaskProvider)
+ * provider?.connect()
+ * console.log(provider?.address)
+ * ```
+ *
+ * @param providerProxy The type of provider from the @rarimo/provider package, such as {@link @rarimo/provider!MetamaskProvider}
+ * @param createProviderOpts Options for the connection
+ */
 export const useProvider = (
   providerProxy: ProviderProxyConstructor,
   createProviderOpts?: CreateProviderOpts,


### PR DESCRIPTION
Adding typedoc for the React package. There is more work to be dome here but I thought it was a start.

The docs for properties are not ideal because I'm having trouble getting the destructured params to show properly. As a workaround, I've been documenting params like this:
```
/**
 * @description Information about the completed transaction
 * @group Components
 *
 * @param props The properties for the component, including:
 * - `isTransactionProcessing`: True if the transaction is not yet complete
 * - `txHash`: The transaction hash
 * - `estimatedPrice`: An {@link @rarimo/nft-checkout!EstimatedPrice} object with information about the transaction price
 */
```

This appears like this: 
![image](https://user-images.githubusercontent.com/6494785/226921229-29cdb06a-4a3b-49ce-86f3-a6474d9a4506.png)


I've also grouped  the functions that provide react parameters in a group via  the `@group` tag:
![image](https://user-images.githubusercontent.com/6494785/226921357-7759d72c-a7db-4455-a9bf-c05edb147f99.png)
