### PR TITLE
Docs for split-up providers packages

### DIFF
--- a/packages/provider/README.md
+++ b/packages/provider/README.md
@@ -1,5 +1,5 @@
 # @rarimo/provider
-Features of the Rarimo SDK that provide access to users' wallets and map extensions for multiple types of wallets (EVM and non-EVM) to a common wallet interface.
+A common interface for access to wallets (EVM and non-EVM) in the Rarimo SDK, used by packages that provide access to wallets on specific chains such as @rarimo/providers-evm, @rarimo/providers-solana, and @rarimo/providers-near.
 
 ![version (scoped package)](https://badgen.net/npm/v/@rarimo/provider)
 ![types](https://badgen.net/npm/types/@rarimo/provider)

--- a/packages/provider/package.json
+++ b/packages/provider/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@rarimo/provider",
   "version": "1.5.0-rc.10",
-  "description": "Features of the Rarimo SDK that provide access to wallets and wrap the wallet extension providers from different EVM and non-EVM chains to one common interface for ease of use",
+  "description": "A common interface for access to wallets (EVM and non-EVM) in the Rarimo SDK, used by packages that provide access to wallets on specific chains such as @rarimo/providers-evm, @rarimo/providers-solana, and @rarimo/providers-near.",
   "repository": {
     "type": "git",
     "url": "https://github.com/rarimo/js-sdk/tree/main/packages/provider"

--- a/packages/providers-evm/README.md
+++ b/packages/providers-evm/README.md
@@ -1,5 +1,5 @@
 # @rarimo/providers-evm
-The EVM wallet wrappers called as Provider in the Rarimo SDK that can be used to interact with the EVM compatible blockchains.
+Features of the Rarimo SDK that provide access to wallets and the ability to interact with them on EVM-compatible blockchains.
 
 ![version (scoped package)](https://badgen.net/npm/v/@rarimo/providers-evm)
 ![types](https://badgen.net/npm/types/@rarimo/providers-evm)

--- a/packages/providers-evm/package.json
+++ b/packages/providers-evm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@rarimo/providers-evm",
   "version": "1.5.0-rc.10",
-  "description": "The EVM wallet wrappers called as Provider in the Rarimo SDK that can be used to interact with the EVM compatible blockchains.",
+  "description": "Features of the Rarimo SDK that provide access to wallets and the ability to interact with them on EVM-compatible blockchains.",
   "repository": {
     "type": "git",
     "url": "https://github.com/rarimo/js-sdk/tree/main/packages/providers-evm"

--- a/packages/providers-near/README.md
+++ b/packages/providers-near/README.md
@@ -1,5 +1,5 @@
 # @rarimo/providers-near
-The Near wallet wrappers called as Provider in the Rarimo SDK that can be used to interact with the Near blockchain.
+Features of the Rarimo SDK that provide access to wallets and the ability to interact with them on the Near blockchain.
 
 ![version (scoped package)](https://badgen.net/npm/v/@rarimo/providers-near)
 ![types](https://badgen.net/npm/types/@rarimo/providers-near)

--- a/packages/providers-near/README.md
+++ b/packages/providers-near/README.md
@@ -1,5 +1,5 @@
 # @rarimo/providers-near
-Features of the Rarimo SDK that provide access to wallets and the ability to interact with them on the Near blockchain.
+Features of the Rarimo SDK that provide access to wallets and the ability to interact with them on the NEAR blockchain.
 
 ![version (scoped package)](https://badgen.net/npm/v/@rarimo/providers-near)
 ![types](https://badgen.net/npm/types/@rarimo/providers-near)

--- a/packages/providers-near/package.json
+++ b/packages/providers-near/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@rarimo/providers-near",
   "version": "1.5.0-rc.10",
-  "description": "Features of the Rarimo SDK that provide access to wallets and the ability to interact with them on the Near blockchain.",
+  "description": "Features of the Rarimo SDK that provide access to wallets and the ability to interact with them on the NEAR blockchain.",
   "repository": {
     "type": "git",
     "url": "https://github.com/rarimo/js-sdk/tree/main/packages/near-providers"

--- a/packages/providers-near/package.json
+++ b/packages/providers-near/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@rarimo/providers-near",
   "version": "1.5.0-rc.10",
-  "description": "The Near wallet wrappers called as Provider in the Rarimo SDK that can be used to interact with the Near blockchain.",
+  "description": "Features of the Rarimo SDK that provide access to wallets and the ability to interact with them on the Near blockchain.",
   "repository": {
     "type": "git",
     "url": "https://github.com/rarimo/js-sdk/tree/main/packages/near-providers"

--- a/packages/providers-solana/README.md
+++ b/packages/providers-solana/README.md
@@ -1,5 +1,5 @@
 # @rarimo/providers-solana
-The Solana wallet wrappers called as Provider in the Rarimo SDK that can be used to interact with the Solana blockchain.
+Features of the Rarimo SDK that provide access to wallets and the ability to interact with them on the Solana blockchain.
 
 ![version (scoped package)](https://badgen.net/npm/v/@rarimo/providers-solana)
 ![types](https://badgen.net/npm/types/@rarimo/providers-solana)

--- a/packages/providers-solana/package.json
+++ b/packages/providers-solana/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@rarimo/providers-solana",
   "version": "1.5.0-rc.10",
-  "description": "The Solana wallet wrappers called as Provider in the Rarimo SDK that can be used to interact with the Solana blockchain.",
+  "description": "Features of the Rarimo SDK that provide access to wallets and the ability to interact with them on the Solana blockchain.",
   "repository": {
     "type": "git",
     "url": "https://github.com/rarimo/js-sdk/tree/main/packages/providers-solana"

--- a/packages/react-provider/README.md
+++ b/packages/react-provider/README.md
@@ -1,5 +1,5 @@
 # @rarimo/react-provider
-Features of the Rarimo SDK that provide access to users' wallets and map extensions for multiple types of wallets (EVM and non-EVM) to a common wallet interface.
+Tools to connect to wallets in React applications through the Rarimo SDK.
 
 ![version (scoped package)](https://badgen.net/npm/v/@rarimo/react-provider)
 ![types](https://badgen.net/npm/types/@rarimo/react-provider)

--- a/packages/react-provider/README.md
+++ b/packages/react-provider/README.md
@@ -14,6 +14,7 @@ Here is an example that creates a `MetamaskProvider` object for a MetaMask walle
 
 ```js
 import { MetamaskProvider } from '@rarimo/provider'
+import { useProvider } from '@rarimo/react-provider'
 
 const { provider, ...rest } = useProvider(MetamaskProvider)
 

--- a/packages/react-provider/package.json
+++ b/packages/react-provider/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@rarimo/react-provider",
   "version": "1.5.0-rc.10",
+  "description": "Tools to connect to wallets in React applications through the Rarimo SDK.",
   "repository": {
     "type": "git",
     "url": "https://github.com/rarimo/js-sdk/tree/main/packages/react-provider"

--- a/packages/react-provider/src/hooks/useProvider.ts
+++ b/packages/react-provider/src/hooks/useProvider.ts
@@ -20,6 +20,10 @@ const PROVIDER_EVENTS: Array<keyof IProvider> = [
   'onDisconnect',
 ]
 
+
+interface useProviderReturnType extends ProviderBase {
+  provider: IProvider
+}
 /**
  * @description A React hook that creates a provider object with access to the user's wallet
  *
@@ -30,13 +34,9 @@ const PROVIDER_EVENTS: Array<keyof IProvider> = [
  * console.log(provider?.address)
  * ```
  *
- * @param providerProxy The type of provider from the @rarimo/provider package, such as {@link @rarimo/provider!MetamaskProvider}
+ * @param providerProxy The type of provider from the appropriate package, such as {@link @rarimo/providers-evm!MetamaskProvider}
  * @param createProviderOpts Options for the connection
  */
-
-interface useProviderReturnType extends ProviderBase {
-  provider: IProvider
-}
 export const useProvider = (
   providerProxy: ProviderProxyConstructor,
   createProviderOpts?: CreateProviderOpts,


### PR DESCRIPTION
Updating the docs for the provider packages now that they are split up into a base package and packages for EVM, Solana, and Near.