### PR TITLE
Don't use the constructors

### DIFF
--- a/packages/providers-evm/src/coinbase.ts
+++ b/packages/providers-evm/src/coinbase.ts
@@ -21,6 +21,9 @@ import { BaseEVMProvider } from './base-evm'
  * ```
  */
 export class CoinbaseProvider extends BaseEVMProvider implements ProviderProxy {
+  /**
+   * @description In most cases, instead of using this constructor, pass the CoinbaseProvider class to {@link @rarimo/provider!createProvider}.
+   */
   constructor(provider?: RawProvider) {
     super(provider)
   }

--- a/packages/providers-evm/src/metamask.ts
+++ b/packages/providers-evm/src/metamask.ts
@@ -21,6 +21,9 @@ import { BaseEVMProvider } from './base-evm'
  * ```
  */
 export class MetamaskProvider extends BaseEVMProvider implements ProviderProxy {
+  /**
+   * @description In most cases, instead of using this constructor, pass the MetamaskProvider class to {@link @rarimo/provider!createProvider}.
+   */
   constructor(provider?: RawProvider) {
     super(provider)
   }

--- a/packages/providers-near/src/near-provider.ts
+++ b/packages/providers-near/src/near-provider.ts
@@ -28,6 +28,9 @@ export class NearProvider extends ProviderEventBus implements ProviderProxy {
   #chainId?: ChainId
   #address?: string
 
+  /**
+   * @description In most cases, instead of using this constructor, pass the NearProvider class to {@link @rarimo/provider!createProvider}.
+   */
   constructor() {
     super()
     this.#provider = this.#provider = new NearRawProvider({})

--- a/packages/providers-solana/src/phantom.ts
+++ b/packages/providers-solana/src/phantom.ts
@@ -39,6 +39,9 @@ export class PhantomProvider
   extends BaseSolanaProvider
   implements ProviderProxy
 {
+  /**
+   * @description In most cases, instead of using this constructor, pass the PhantomProvider class to {@link @rarimo/provider!createProvider}.
+   */
   constructor(provider?: RawProvider) {
     super(provider)
   }

--- a/packages/providers-solana/src/solflare.ts
+++ b/packages/providers-solana/src/solflare.ts
@@ -39,6 +39,9 @@ export class SolflareProvider
   extends BaseSolanaProvider
   implements ProviderProxy
 {
+  /**
+   * @description In most cases, instead of using this constructor, pass the SolflareProvider class to {@link @rarimo/provider!createProvider}.
+   */
   constructor(provider?: RawProvider) {
     super(provider)
   }


### PR DESCRIPTION
Does it make sense to add a note to not use the constructors for the provider classes? People might assume that they could do `const myProvider = new CoinbaseProvider()` instead of using `createProvider()`.

We could also use the `@hidden` tag to hide the constructor from the documentation.