### PR TITLE
Clarify that loadPaymentTokens returns only the tokens that have sufficient balance for the operation

### DIFF
--- a/packages/nft-checkout/src/types/operation.ts
+++ b/packages/nft-checkout/src/types/operation.ts
@@ -44,7 +44,7 @@ export interface CheckoutOperation extends OperationSubscriber {
    */
   loadSupportedChains(): Promise<BridgeChain[]>
   /**
-   * Load the wallet's balance of payment tokens on the specified chain.
+   * Load the tokens that the wallet has enough of to run the operation.
    *
    * @param chain - A chain from {@link supportedChains}
    * @returns An array of tokens and the wallet's balance of each token


### PR DESCRIPTION
This function returns only the tokens that the wallet has enough of for the operation, not all tokens.