### PR TITLE
This @rarimo tag breaks doc generation

### DIFF
--- a/packages/shared/README.md
+++ b/packages/shared/README.md
@@ -1,5 +1,5 @@
 # @rarimo/shared
-Utility functions, types, and constants shared across @rarimo packages.
+Utility functions, types, and constants shared across Rarimo packages.
 
 ![version (scoped package)](https://badgen.net/npm/v/@rarimo/shared)
 ![types](https://badgen.net/npm/types/@rarimo/shared)

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@rarimo/shared",
   "version": "2.0.0-rc.7",
-  "description": "Utility functions, types and constants shared across @rarimo packages.",
+  "description": "Utility functions, types and constants shared across Rarimo packages.",
   "repository": {
     "type": "git",
     "url": "https://github.com/rarimo/js-sdk.git",


### PR DESCRIPTION
Just like https://github.com/rarimo/js-sdk/pull/53.

![image](https://github.com/rarimo/js-sdk/assets/6494785/0eee785e-9497-487f-a7db-0eebde70e1ac)
